### PR TITLE
ci: use repo for clang-hook instead of local

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -11,10 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install clang
-        run: |
-          sudo apt install
-          sudo apt install -y clang-format
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,7 @@ repos:
         args:
           - --fix=lf
       - id: end-of-file-fixer
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.6
     hooks:
       - id: clang-format
-        name: clang-format
-        entry: clang-format
-        'types_or': [c, c++]
-        language: system
-        args: [-Werror, -i, --style=file]


### PR DESCRIPTION
clang-format is now available as python wheels. This makes it cleaner to include it in pre-commit, the proper repository has been setup instead of using the machine's local executable.