### PR TITLE
build: implement clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: 'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,modernize-*,bugprone-*,readability-*,-cppcoreguidelines-avoid-non-const-global-variables'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,modernize-*,bugprone-*,readability-*,-cppcoreguidelines-avoid-non-const-global-variables'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,3 +4,9 @@ target_link_libraries(adc_read startupf401xc ${CRT0_OBJ} ${CRT_OBJ})
 add_executable(blink blink.c)
 target_link_libraries(blink startupf401xc freertos ${CRT0_OBJ} ${CRT_OBJ})
 generate_object(blink .hex ihex)
+
+set_target_properties(
+    blink
+    PROPERTIES
+    C_CLANG_TIDY "clang-tidy"
+)

--- a/src/blink.c
+++ b/src/blink.c
@@ -1,38 +1,44 @@
 #include <FreeRTOS.h>
 #include <task.h>
 
+const uint8_t MCO1PRE_DIV4 = 0x06;
+const uint8_t MCO1_PPL = 0x03;
+const uint8_t PPRE1_DIV2 = 0x04;
+
 static TaskHandle_t blinkTaskHandle;
 
 void setupHardware(void) {
     __disable_irq();
     FLASH->ACR |= FLASH_ACR_LATENCY_2WS;
-    while ((FLASH->ACR & FLASH_ACR_LATENCY) != FLASH_ACR_LATENCY_2WS) continue;
+    while ((FLASH->ACR & FLASH_ACR_LATENCY) != FLASH_ACR_LATENCY_2WS) {}
 
-    RCC->CFGR |= (0x06 << RCC_CFGR_MCO1PRE_Pos) | (0x03 << RCC_CFGR_MCO1_Pos) | (0x04 << RCC_CFGR_PPRE1_Pos);
+    RCC->CFGR |=
+        (MCO1PRE_DIV4 << RCC_CFGR_MCO1PRE_Pos) | (MCO1_PPL << RCC_CFGR_MCO1_Pos) | (PPRE1_DIV2 << RCC_CFGR_PPRE1_Pos);
 
     RCC->CR |= RCC_CR_HSEON;
-    while ((RCC->CR & RCC_CR_HSERDY) == 0) continue;
+    while ((RCC->CR & RCC_CR_HSERDY) == 0) {}
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
     RCC->PLLCFGR = (6 << RCC_PLLCFGR_PLLQ_Pos) | (288 << RCC_PLLCFGR_PLLN_Pos) | (25 << RCC_PLLCFGR_PLLM_Pos) |
-                   (0x01 << RCC_PLLCFGR_PLLP_Pos) | RCC_PLLCFGR_PLLSRC_HSE;
+                   (1 << RCC_PLLCFGR_PLLP_Pos) | RCC_PLLCFGR_PLLSRC_HSE;
     RCC->CR |= RCC_CR_PLLON;
-    while ((RCC->CR & RCC_CR_PLLRDY) == 0) continue;
+    while ((RCC->CR & RCC_CR_PLLRDY) == 0) {}
 
     RCC->CFGR |= RCC_CFGR_SW_PLL;
-    while ((RCC->CFGR & RCC_CFGR_SWS) == 0) continue;
+    while ((RCC->CFGR & RCC_CFGR_SWS) == 0) {}
 
     SystemCoreClockUpdate();
-    SysTick_Config(SystemCoreClock / 1000);
+    SysTick_Config(SystemCoreClock / configTICK_RATE_HZ);
 
     RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN;
-    GPIOC->ODR = 0x00;
-    GPIOC->MODER = 0x01 << GPIO_MODER_MODER13_Pos;
+    GPIOC->ODR = 0;
+    GPIOC->MODER = 1 << GPIO_MODER_MODER13_Pos;
 }
 
 void blinkLedTask(void *pvParameters) {
     (void)pvParameters;
     while (1) {
-        GPIOC->ODR = 0xFFFFFFFF;
+        GPIOC->ODR |= 1 << GPIO_ODR_OD13_Pos;
         vTaskDelay(pdMS_TO_TICKS(1000));
         GPIOC->ODR = 0;
         vTaskDelay(pdMS_TO_TICKS(1000));


### PR DESCRIPTION
clang-tidy now runs during compilation. It will treat warning as errors during the build process, ensuring all checks are taken care of.